### PR TITLE
Service handling ported to systemd (bsc#926485)

### DIFF
--- a/src/include/sysconfig/complex.rb
+++ b/src/include/sysconfig/complex.rb
@@ -780,7 +780,7 @@ module Yast
         id = Ops.get_string(i, [0, 0], "")
         title = Ops.get_string(i, 1, "")
         enabled = Ops.get_boolean(i, 2, false)
-        children = Ops.get_list(i, 3, [])
+        children = i[3] || []
         _Tree = Wizard.AddTreeItem(_Tree, parent, title, id)
         if Ops.greater_than(Builtins.size(children), 0)
           _Tree = GenerateTree(_Tree, id, children)


### PR DESCRIPTION
`This PR is not to be merged yet, I still have time till Wednesday afternoon, then please take over or trash it, but I believe the solution is on a good way`

PR taken over by @ancorgs 

- No more /etc/init.d/* just systemctl (Services API)
- The code has been manually tested, there is no testsuite yet! because it needs to be split into separate methods first