### PR TITLE
Security Audit Fixes: Calling External Commands and Absolute Paths and Quoted Arguments

### DIFF
--- a/package/yast2-sysconfig.changes
+++ b/package/yast2-sysconfig.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Dec  4 13:27:20 UTC 2018 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Security audit fix: Documented external command usage and added
+  warning if calling an external command without an absolute path
+  (bsc#1118291)
+- 4.1.2
+
+-------------------------------------------------------------------
 Mon Nov 26 05:04:52 UTC 2018 - Noah Davis <noahadvs@gmail.com>
 
 - Provide icon with module (boo#1109310)

--- a/package/yast2-sysconfig.spec
+++ b/package/yast2-sysconfig.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-sysconfig
-Version:        4.1.1
+Version:        4.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/Sysconfig.rb
+++ b/src/modules/Sysconfig.rb
@@ -1133,7 +1133,23 @@ module Yast
       error = Builtins.sformat(_("Command %1 failed"), cmd)
       confirm = _("A command will be executed") + "\n" + _("Command: ") + cmd
 
+      # Any command executed here is taken verbatim from a file in
+      # /etc/sysconfig. The command should contain an absolute path, and if it
+      # has any arguments, they should be properly quoted.
+      #
+      # There does not seem to be a single example where such a command has any
+      # arguments, though.
+      #
+      # Example specification from /etc/sysconfig/fonts-config:
+      #
+      #   ## Command:     /usr/sbin/fonts-config
+      #
+      # Specification:
+      #  https://github.com/yast/yast-sysconfig/blob/master/doc/metadata.txt#L141-L159
+
       action = lambda do
+        log.warn("No absolute path in command #{cmd}") unless cmd.lstrip.start_with?("/")
+
         log.info "Starting: #{cmd}"
         cmd_out = SCR.Execute(path(".target.bash_output"), "#{cmd} 2>&1")
         log.info "Result: #{cmd_out['exit']}"


### PR DESCRIPTION
This is part of the YaST security audit by @jsegitz.

From the audit:

> yast2-sysconfig/yast2-sysconfig-4.1.0/src/modules/Sysconfig.rb:1131
>
> exec_cmd_action should be reworked to receive an absolut path and arguments that then can be quoted/escaped

Affected code:

https://github.com/yast/yast-sysconfig/blob/master/src/modules/Sysconfig.rb#L1131

Spec of those commands:

https://github.com/yast/yast-sysconfig/blob/master/doc/metadata.txt#L141-L159

Example:

From /etc/sysconfig/fonts-config:

```
## Path:        Desktop
## Description: Display font configuration
## Type:        yesno
## Default:     no
## Command:     /usr/sbin/fonts-config
#
#  Force autohint even for fonts, which are said to have good
#  hinting instructions.
#
FORCE_AUTOHINT="no"
```

The command that is executed is taken verbatim from such a comment in an /etc/sysconfig file.
Those files are provided by the package that is being configured with it; they are located in /etc/sysconfig which has restricted permisisons, and each file is by default owned by root/root hand has permissions `rw-r--r--` (0644) or `rw-------` (0640), so it is not any arbitrary code that can be executed.

There is a number of files in /etc/sysconfig that contains such commands, but there does not appear to be a single one where the command is not speficied with an absolute path or where the command has any arguments.

Still, now the code that executes the command checks if it has an absolute path and, if it does not, logs a warning.

There is really not that much more than we can do without potentially breaking packages that rely on the existing behaviour. The commands come from a well-controlled environment, the command line is taken from a comment line in an /etc/sysconfig file where no shell interferes with any quoting, so any quoting used there will be taken verbatim to the command line.

We can't do anything with the command line without fear of breaking something; if any package really uses that to do more than just call a binary without any argument, it should already quote the arguments properly. If we quote them again, we might break the command.

But this is most likely a moot point; as mentioned above, there does not seem to be a single case where any such command does use any argument.