### PR TITLE
Fix popup test

### DIFF
--- a/package/yast2-sysconfig.changes
+++ b/package/yast2-sysconfig.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 15 07:43:53 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.3
+
+-------------------------------------------------------------------
 Mon Aug 10 16:48:09 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(sysconfig) into the spec file

--- a/package/yast2-sysconfig.spec
+++ b/package/yast2-sysconfig.spec
@@ -18,7 +18,7 @@
 
 Name:           yast2-sysconfig
 Summary:        YaST2 - Sysconfig Editor
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Url:            https://github.com/yast/yast-sysconfig
 Group:          System/YaST


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.